### PR TITLE
fix: remove dependency on lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "cookie": "^0.1.2",
-    "lodash": "^4.16.1"
+    "lodash.pick": "^4.4.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",

--- a/src/save.js
+++ b/src/save.js
@@ -4,7 +4,7 @@
  */
 
 const cookie = require('cookie');
-const _pick = require('lodash/pick');
+const _pick = require('lodash.pick');
 
 import { encode } from './encoding';
 import { isResWritable } from './util';


### PR DESCRIPTION
isomorphic-cookie currently loads a huge chunk of lodash for just one function. By changing the dependency to lodash.pick instead of lodash, this dependency is much smaller. 